### PR TITLE
Added interruption status to daily allocation summary email

### DIFF
--- a/ParkingRota.Business/Emails/DailySummary.cs
+++ b/ParkingRota.Business/Emails/DailySummary.cs
@@ -21,7 +21,14 @@
 
         public string To => this.recipient.Email;
 
-        public string Subject => $"Daily allocations summary for {this.FormattedDate}";
+        public string Subject
+        {
+            get
+            {
+                var status = this.allocations.Any(a => a.ApplicationUser == recipient) ? "ALLOCATED" : "INTERRUPTED";
+                return $"[{status}] {this.FormattedDate} Daily allocations summary";
+            }
+        }
 
         public string HtmlBody
         {

--- a/ParkingRota.Business/Emails/DailySummary.cs
+++ b/ParkingRota.Business/Emails/DailySummary.cs
@@ -25,7 +25,7 @@
         {
             get
             {
-                var status = this.allocations.Any(a => a.ApplicationUser == recipient) ? "ALLOCATED" : "INTERRUPTED";
+                var status = this.allocations.Any(a => a.ApplicationUser == this.recipient) ? "Allocated" : "INTERRUPTED";
                 return $"[{status}] {this.FormattedDate} Daily allocations summary";
             }
         }

--- a/ParkingRota.UnitTests/Business/Emails/DailySummaryTests.cs
+++ b/ParkingRota.UnitTests/Business/Emails/DailySummaryTests.cs
@@ -41,7 +41,7 @@
 
             var email = new DailySummary(recipient, allocations, requests);
 
-            Assert.Equal("[ALLOCATED] 18 Dec Daily allocations summary", email.Subject);
+            Assert.Equal("[Allocated] 18 Dec Daily allocations summary", email.Subject);
         }
 
         [Fact]

--- a/ParkingRota.UnitTests/Business/Emails/DailySummaryTests.cs
+++ b/ParkingRota.UnitTests/Business/Emails/DailySummaryTests.cs
@@ -25,13 +25,43 @@
         }
 
         [Fact]
-        public static void TestSubject()
+        public static void TestSubject_RecipientAllocated()
         {
-            var allocations = new[] { new Allocation { Date = 18.December(2018) } };
+            var date = 18.December(2018);
 
-            var email = new DailySummary(new ApplicationUser(), allocations, default(IReadOnlyList<Request>));
+            var recipient = Create.User("Pierre-Emerick Aubameyang");
 
-            Assert.Equal("Daily allocations summary for 18 Dec", email.Subject);
+            var allocatedUsers = Create.Users("Petr Čech", "Héctor Bellerín").Concat(new[] { recipient });
+            var interruptedUsers = Create.Users("Sokratis Papastathopoulos", "Mohamed Elneny");
+
+            var allUsers = allocatedUsers.Concat(interruptedUsers);
+
+            var allocations = Create.Allocations(allocatedUsers, date);
+            var requests = Create.Requests(allUsers, date);
+
+            var email = new DailySummary(recipient, allocations, requests);
+
+            Assert.Equal("[ALLOCATED] 18 Dec Daily allocations summary", email.Subject);
+        }
+
+        [Fact]
+        public static void TestSubject_RecipientInterrupted()
+        {
+            var date = 18.December(2018);
+
+            var recipient = Create.User("Pierre-Emerick Aubameyang");
+
+            var allocatedUsers = Create.Users("Petr Čech", "Héctor Bellerín");
+            var interruptedUsers = Create.Users("Sokratis Papastathopoulos", "Mohamed Elneny").Concat(new[] { recipient });
+
+            var allUsers = allocatedUsers.Concat(interruptedUsers);
+
+            var allocations = Create.Allocations(allocatedUsers, date);
+            var requests = Create.Requests(allUsers, date);
+
+            var email = new DailySummary(recipient, allocations, requests);
+
+            Assert.Equal("[INTERRUPTED] 18 Dec Daily allocations summary", email.Subject);
         }
 
         [Fact]


### PR DESCRIPTION
PR for #11.

Have moved the date earlier in the subject, so it's more prominent.

Haven't actually been able to test this out, as I had trouble getting a local version up and running. Would be worth testing before merging I think.